### PR TITLE
Test: Add getTasksByTitle Test

### DIFF
--- a/src/main/java/com/tasksapp/repository/TaskRepository.java
+++ b/src/main/java/com/tasksapp/repository/TaskRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
+
+    public List<Task> getTaskByTitleContainsIgnoreCase(String targetTitle);
 }

--- a/src/test/java/com/tasksapp/service/TaskServiceTest.java
+++ b/src/test/java/com/tasksapp/service/TaskServiceTest.java
@@ -47,4 +47,21 @@ class TaskServiceTest {
         assertThat(result).isEqualTo(taskList);
     }
 
+    @Test
+    public void testGetTasksByTitleReturnsMatchedTask() {
+        String targetTitle = "Specific Task";
+
+        List<Task> taskList = Arrays.asList(
+                Task.builder().title(targetTitle).status(TaskStatus.INCOMPLETE).priority(TaskPriority.MEDIUM).description("This is a specific task.").build(),
+                Task.builder().title("Other Task").status(TaskStatus.INCOMPLETE).priority(TaskPriority.LOW).description("This is another task.").build()
+        );
+
+        List<Task> expected = taskList.stream().filter(task -> task.getTitle().equals(targetTitle)).toList();
+        List<Task> result = taskServiceImpl.getTasksByTitle(targetTitle);
+
+        when(mockTaskRepository.getTaskByTitleContainsIgnoreCase(targetTitle)).thenReturn(expected);
+
+        assertThat(result).isEqualTo(expected);
+    }
+
 }


### PR DESCRIPTION
- Updated TaskRepository getTaskByTitleContainsIgnoreCase method to return list of taks
- Added 'testGetTasksReturnsListOfAllTasks' test case to ensure method correctly returns tasks with the requested title